### PR TITLE
Cycle CI testing up to python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
 
@@ -45,7 +45,7 @@ jobs:
         python -m coverage xml
 
     - name: Upload coverage
-      if: ${{ matrix.python-version == '3.12' }}
+      if: ${{ matrix.python-version == '3.13' }}
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
@@ -60,7 +60,7 @@ jobs:
 
     # This is somewhat suboptimal
     - name: Deploy docs
-      if: ${{ matrix.python-version == '3.12' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
+      if: ${{ matrix.python-version == '3.13' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages # The branch the action should deploy to.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.3
+    rev: v0.12.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
Leaves python 3.9 as minimum python, for now.